### PR TITLE
fix: Fix issue where Mongodb stream doesn't get closed

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # Platform metadata for releases, POM generation, etc.
 ##################################################
 group=org.apereo.cas
-version=6.5.9.0.ksu.1
+version=6.5.9.0.ksu.2
 projectUrl=https://www.apereo.org/cas
 projectInceptionYear=2004
 projectScmUrl=scm:git@github.com:apereo/cas.git

--- a/support/cas-server-support-events-mongo/src/main/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepository.java
+++ b/support/cas-server-support-events-mongo/src/main/java/org/apereo/cas/support/events/mongo/MongoDbCasEventRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 
 import java.time.ZonedDateTime;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -36,21 +37,22 @@ public class MongoDbCasEventRepository extends AbstractCasEventRepository {
 
     @Override
     public Stream<? extends CasEvent> load() {
-        return this.mongoTemplate.stream(new Query(), CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(new Query());
     }
 
     @Override
     public Stream<? extends CasEvent> load(final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(query);
+
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsOfTypeForPrincipal(final String type, final String principal) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type).and(PRINCIPAL_ID_PARAM).is(principal));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(query);
     }
 
     @Override
@@ -59,37 +61,45 @@ public class MongoDbCasEventRepository extends AbstractCasEventRepository {
                                                                   final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type)
-            .and(PRINCIPAL_ID_PARAM).is(principal)
-            .and(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+                .and(PRINCIPAL_ID_PARAM).is(principal)
+                .and(CREATION_TIME_PARAM).gte(dateTime.toString()));
+        return getCasEventStream(query);
+
+    }
+
+    private Stream<CasEvent> getCasEventStream(final Query query) {
+        try (val stream = this.mongoTemplate.stream(query, CasEvent.class, this.collectionName)){
+            val list = stream.stream().collect(Collectors.toList());
+            return list.stream();
+        }
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsOfType(final String type) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(query);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsOfType(final String type, final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(TYPE_PARAM).is(type).and(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(query);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsForPrincipal(final String id) {
         val query = new Query();
         query.addCriteria(Criteria.where(PRINCIPAL_ID_PARAM).is(id));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(query);
     }
 
     @Override
     public Stream<? extends CasEvent> getEventsForPrincipal(final String principal, final ZonedDateTime dateTime) {
         val query = new Query();
         query.addCriteria(Criteria.where(PRINCIPAL_ID_PARAM).is(principal).and(CREATION_TIME_PARAM).gte(dateTime.toString()));
-        return this.mongoTemplate.stream(query, CasEvent.class, this.collectionName).stream();
+        return getCasEventStream(query);
     }
 
     @Override


### PR DESCRIPTION
The MongoDBTemplate.stream() method returns a 'stream' of a mongodb cursor using a closable iterator. Nothing before this pull request is explicitly closing the iterator, leaving it up to garbage collection. Amazon DocumentDB has a fairly load cursor count (400) for R6.Xlarge instances, and we are running into it running a load test with 10 users with all the features of risk based authentication turned on. This change explicitly closes the stream via try with resources. This prevents the issue we are seeing.