### PR TITLE
refactor: Move  events to RiskEvaluator to improve performance

### DIFF
--- a/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/api/AuthenticationRequestRiskCalculator.java
+++ b/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/api/AuthenticationRequestRiskCalculator.java
@@ -2,9 +2,12 @@ package org.apereo.cas.api;
 
 import org.apereo.cas.authentication.Authentication;
 import org.apereo.cas.services.RegisteredService;
+import org.apereo.cas.support.events.dao.CasEvent;
 
 import javax.servlet.http.HttpServletRequest;
 import java.math.BigDecimal;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 /**
  * This is {@link AuthenticationRequestRiskCalculator}.
@@ -30,9 +33,11 @@ public interface AuthenticationRequestRiskCalculator {
      * @param authentication the authentication
      * @param service        the service
      * @param request        the request
+     * @param events         the events
      * @return the authentication risk score
      */
     AuthenticationRiskScore calculate(Authentication authentication,
                                       RegisteredService service,
-                                      HttpServletRequest request);
+                                      HttpServletRequest request,
+                                      Supplier<Stream<? extends CasEvent>> events);
 }

--- a/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/config/ElectronicFenceConfiguration.java
+++ b/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/config/ElectronicFenceConfiguration.java
@@ -80,8 +80,10 @@ public class ElectronicFenceConfiguration {
         @Bean
         @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
         public AuthenticationRiskEvaluator authenticationRiskEvaluator(
-            final List<AuthenticationRequestRiskCalculator> ipAddressAuthenticationRequestRiskCalculators) {
-            return new DefaultAuthenticationRiskEvaluator(ipAddressAuthenticationRequestRiskCalculators);
+            final List<AuthenticationRequestRiskCalculator> ipAddressAuthenticationRequestRiskCalculators,
+            @Qualifier("casEventRepository") final CasEventRepository casEventRepository,
+            final CasConfigurationProperties casProperties) {
+            return new DefaultAuthenticationRiskEvaluator(ipAddressAuthenticationRequestRiskCalculators, casEventRepository, casProperties);
         }
     }
 

--- a/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/impl/engine/DefaultAuthenticationRiskEvaluator.java
+++ b/support/cas-server-support-electrofence/src/main/java/org/apereo/cas/impl/engine/DefaultAuthenticationRiskEvaluator.java
@@ -1,5 +1,6 @@
 package org.apereo.cas.impl.engine;
 
+
 import org.apereo.cas.api.AuthenticationRequestRiskCalculator;
 import org.apereo.cas.api.AuthenticationRiskEvaluator;
 import org.apereo.cas.api.AuthenticationRiskScore;
@@ -7,18 +8,29 @@ import org.apereo.cas.audit.AuditActionResolvers;
 import org.apereo.cas.audit.AuditResourceResolvers;
 import org.apereo.cas.audit.AuditableActions;
 import org.apereo.cas.authentication.Authentication;
+import org.apereo.cas.configuration.CasConfigurationProperties;
 import org.apereo.cas.services.RegisteredService;
+import org.apereo.cas.support.events.CasEventRepository;
+import org.apereo.cas.support.events.dao.CasEvent;
+import org.apereo.cas.support.events.ticket.CasTicketGrantingTicketCreatedEvent;
+
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import lombok.val;
 import org.apereo.inspektr.audit.annotation.Audit;
-
 import javax.servlet.http.HttpServletRequest;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * This is {@link DefaultAuthenticationRiskEvaluator}.
@@ -26,10 +38,18 @@ import java.util.List;
  * @author Misagh Moayyed
  * @since 5.1.0
  */
+@Slf4j
 @Getter
 @RequiredArgsConstructor
 public class DefaultAuthenticationRiskEvaluator implements AuthenticationRiskEvaluator {
     private final List<AuthenticationRequestRiskCalculator> calculators;
+
+    private final CasEventRepository casEventRepository;
+
+    /**
+     * CAS settings.
+     */
+    private final CasConfigurationProperties casProperties;
 
     @Audit(action = AuditableActions.EVALUATE_RISKY_AUTHENTICATION,
         actionResolverName = AuditActionResolvers.ADAPTIVE_RISKY_AUTHENTICATION_ACTION_RESOLVER,
@@ -43,9 +63,37 @@ public class DefaultAuthenticationRiskEvaluator implements AuthenticationRiskEva
         }
 
         val scores = new ArrayList<AuthenticationRiskScore>(this.calculators.size());
-        this.calculators.forEach(r -> scores.add(r.calculate(authentication, service, request)));
+        val principal = authentication.getPrincipal();
+        val events = new Supplier<Stream<? extends CasEvent>>() {
+            private List<? extends CasEvent> dataList = Collections.EMPTY_LIST;
+            @Override
+            public Stream<? extends CasEvent> get() {
+                if (dataList.isEmpty()){
+                    try (val stream = getCasTicketGrantingTicketCreatedEventsFor(principal.getId())) {
+                        dataList = stream.collect(Collectors.toList());
+                    }
+                }
+                return dataList.stream();
+            }
+        };
+        this.calculators.forEach(r -> scores.add(r.calculate(authentication, service, request, events)));
         val sum = scores.stream().map(AuthenticationRiskScore::getScore).reduce(BigDecimal.ZERO, BigDecimal::add);
         val score = sum.divide(BigDecimal.valueOf(this.calculators.size()), 2, RoundingMode.UP);
         return new AuthenticationRiskScore(score);
+    }
+
+    /**
+     * Gets cas ticket granting ticket created events.
+     *
+     * @param principal the principal
+     * @return the cas ticket granting ticket created events for
+     */
+    protected Stream<? extends CasEvent> getCasTicketGrantingTicketCreatedEventsFor(final String principal) {
+        val type = CasTicketGrantingTicketCreatedEvent.class.getName();
+        LOGGER.debug("Retrieving events of type [{}] for [{}]", type, principal);
+
+        val date = ZonedDateTime.now(ZoneOffset.UTC)
+                .minusDays(casProperties.getAuthn().getAdaptive().getRisk().getDaysInRecentHistory());
+        return casEventRepository.getEventsOfTypeForPrincipal(type, principal, date);
     }
 }


### PR DESCRIPTION
Previous code was running the same query 3 times per risk-calculator enabled.
This modifies it to run the query once, cache in a list, and re-use for the other  calculators.

<!--

# Details

Thank you for your contributions to Apereo CAS.

When you publish the pull request, please check off relevant items below in the description of your pull request.

Please make sure you include the following:

- [] Brief description of changes applied
- [] Test cases for all modified changes, where applicable
- [] The same pull request targeted at the master branch, if applicable
- [] Any documentation on how to configure, test
- [] Any possible limitations, side effects, etc
- [] Reference any other pull requests that might be related

For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).

If your pull request targets a maintenance branch and is not directed at `master`, make sure your reference the pull request that
has already ported your changes forward to the `master` branch. You may do so by including the following in your pull request description:

```
master: https://github.com/apereo/cas/pull/$PR_NUMBER
```

Do not keep this template as is when you submit. Please remove or adjust the description when you submit your pull request.

If you have questions, please [reach out](https://apereo.github.io/cas/Mailing-Lists.html).

Thanks again!
-->
